### PR TITLE
History redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,21 +25,21 @@ To start, run mongod, pointed to the database directory, then start up the serve
 
 ## Usage
 
-Once the server is running, the current weather in selected locations can be queried via simple HTTP requests on port 3000, from the appropriate url:
+Once the server is running, the current weather in selected locations can be queried via HTTP GET on port 3000, from the appropriate url, composed of the name of the city (one of three) and the date in YYYYMMDD format:
 
-* /london -> London, England
-* /tampere -> Tampere, Finland
-* /durham -> Durham, NC, USA
+* /london/YYYYMMDD -> London, England
+* /tampere/YYYYMMDD -> Tampere, Finland
+* /durham/YYYYMMDD -> Durham, NC, USA
 
 The server will serve up the current temp and weather in these locations as an XML response, containing the location name, temp (in Celsius), and weather condition. 
 
-Example output from `localhost:3000\london`: 
+Example mock output from `localhost:3000\london\20100515`: 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <response>
-	<location>London, United Kingdom</location>
-	<temp>14</temp>
-	<weather>Clear</weather>
+	<location>London, England</location>
+	<temp>11</temp>
+	<weather>Cloudy</weather>
 </response>
 ```
 

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,8 @@
                  [ring/ring-defaults "0.1.2"]
                  [org.clojure/data.xml "0.0.8"]
                  [com.novemberain/monger "2.0.1"]
-                 [clj-time "0.8.0"]]
+                 [clj-time "0.8.0"]
+                 [ororo "0.1.0"]]
   :plugins [[lein-ring "0.8.13"]]
   :ring {:handler wunderprojectj.handler/app}
   :profiles

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,6 @@
                  [ring/ring-defaults "0.1.2"]
                  [org.clojure/data.xml "0.0.8"]
                  [com.novemberain/monger "2.0.1"]
-                 [clj-time "0.8.0"]
                  [ororo "0.1.0"]]
   :plugins [[lein-ring "0.8.13"]]
   :ring {:handler wunderprojectj.handler/app}

--- a/src/wunderprojectj/handler.clj
+++ b/src/wunderprojectj/handler.clj
@@ -5,9 +5,9 @@
             [wunderprojectj.weather.checkdb :as weather]))
 
 (defroutes app-routes
-  (GET "/london" [] (fn [req] (weather/query-city ["London" "England"])))
-  (GET "/durham" [] (fn [req] (weather/query-city ["Durham" "NC"])))
-  (GET "/tampere" [] (fn [req] (weather/query-city ["Tampere" "Finland"])))
+  (GET "/london/:date" [date] (fn [req] (weather/query-city ["London" "England"] date)))
+  (GET "/durham/:date" [date] (fn [req] (weather/query-city ["Durham" "NC"] date)))
+  (GET "/tampere/:date" [date] (fn [req] (weather/query-city ["Tampere" "Finland"] date)))
   (route/not-found "Not Found"))
 
 (def app

--- a/src/wunderprojectj/weather/checkdb.clj
+++ b/src/wunderprojectj/weather/checkdb.clj
@@ -1,7 +1,6 @@
 (ns wunderprojectj.weather.checkdb
   (:require [monger.core :as mg]
             [monger.collection :as mc]
-            [clj-time.core :as time]
             [wunderprojectj.weather.getdata :as weather]))
 
 (def conn (mg/connect))
@@ -28,9 +27,8 @@
   "Takes a city (a vector containing city at index 1 and country/state at index 2)
    queries the DB for a cached result from the current day and returns it if found
    or requests a new result if not found"
-  [city]
-  (let [date (clojure.string/join (remove #(= % \-) (str (time/today))))
-        coll (first city)]
+  [city date]
+  (let [coll (first city)]
     (if-let [exists (date-exists coll date)]
       exists
       (cache-new coll date city))))

--- a/src/wunderprojectj/weather/checkdb.clj
+++ b/src/wunderprojectj/weather/checkdb.clj
@@ -20,7 +20,7 @@
   "Makes an API request for the name and date, stores it to the local DB, 
    and returns it"
   [coll date city]
-  (let [result (apply weather/weather-query city)]
+  (let [result (weather/weather-query city date)]
     (mc/insert db coll {:date date :response result})
     result))
 
@@ -29,7 +29,7 @@
    queries the DB for a cached result from the current day and returns it if found
    or requests a new result if not found"
   [city]
-  (let [date (str (time/today))
+  (let [date (clojure.string/join (remove #(= % \-) (str (time/today))))
         coll (first city)]
     (if-let [exists (date-exists coll date)]
       exists

--- a/src/wunderprojectj/weather/getdata.clj
+++ b/src/wunderprojectj/weather/getdata.clj
@@ -1,6 +1,5 @@
 (ns wunderprojectj.weather.getdata
-  (:require [clojure.xml :as xml]
-            [clojure.data.xml :as d-xml]
+  (:require [clojure.data.xml :as d-xml]
             [ororo.core :as ororo]))
 
 ;; We slurp the API key from a file so that the key can be kept private
@@ -20,7 +19,7 @@
     (->> omap last :conds)))
 
 (defn get-simple
-  "Returns a simplified map containing just the temp and weather"
+  "Returns a simplified map containing just the location, temp and weather"
   [loc wmap]
   (let [loc (clojure.string/join ", " loc)
         temp (->> wmap :dailysummary first :meantempm)

--- a/src/wunderprojectj/weather/getdata.clj
+++ b/src/wunderprojectj/weather/getdata.clj
@@ -1,42 +1,33 @@
 (ns wunderprojectj.weather.getdata
   (:require [clojure.xml :as xml]
-            [clojure.data.xml :as d-xml]))
+            [clojure.data.xml :as d-xml]
+            [ororo.core :as ororo]))
 
 ;; We slurp the API key from a file so that the key can be kept private
 (def api-key (slurp "./resources/private/wapikey.txt"))
 
 ;; Functions
-(defn make-url
-  "Given a country or a two-letter state followed by a city, returns a 
-   Wunderground API URL"
-  [c-s city]
-  (str "http://api.wunderground.com/api/" 
-       api-key "/conditions/q/" c-s "/" city ".xml"))
-
-(defn get-conditions
-  "Returns a map of the current weather conditions"
-  [url]
-  (->> 
-    (xml/parse url)
-    :content
-    (filter #(= (:tag %) :current_observation))
-    first
-    :content
-    (mapv #(let [nk (:tag %)
-                 nv (:content %)]
-             (hash-map nk nv)))
-    (reduce conj)))
+(defn find-conds
+  "Given a list of observation maps, returns an estimation of weather conditions 
+   for that day by grabbing either mid-day or the last available"
+  [omap]
+  (if-let [weather (->>
+                     omap
+                     (filter #(= (:hour (:date %)) "12"))
+                     first
+                     :conds)]
+    weather
+    (->> omap last :conds)))
 
 (defn get-simple
   "Returns a simplified map containing just the temp and weather"
-  [wmap]
-  (let [loc (->> 
-              wmap
-              :display_location
-              first
-              :content)
-        temp (assoc (select-keys wmap [:temp_c :weather]) :location loc)] 
-    (zipmap (keys temp) (map first (vals temp)))))
+  [loc wmap]
+  (let [loc (clojure.string/join ", " loc)
+        temp (->> wmap :dailysummary first :meantempm)
+        conds (find-conds (:observations wmap))] 
+    {:location loc
+     :temp temp 
+     :weather conds}))
 
 (defn simple->xml
   "Takes the simplified map of get-simple and returns an assembled XML response"
@@ -44,16 +35,15 @@
   (d-xml/sexp-as-element
     [:response
      [:location (:location smap)]
-     [:temp (:temp_c smap)]
+     [:temp (:temp smap)]
      [:weather (:weather smap)]]))
 
 (defn weather-query
-  "Given a city and country/state, returns XML response with location,
+  "Given a location and date, returns XML response with location,
    current temp in C, and weather"
-  [city cs]
+  [loc date]
   (->> 
-    (make-url cs city)
-    get-conditions
-    get-simple
+    (ororo/history api-key loc date)
+    (get-simple loc)
     simple->xml
     d-xml/emit-str))


### PR DESCRIPTION
The API has now been redesigned to support a date parameter, and can thus return what is hoped to be reasonably accurate historical weather data. Past dates are polled based on mean temperature and conditions at mid-day; current date is taken from the most recent observation available. Documentation has been updated accordingly. 
